### PR TITLE
학교 이름의 갯수를 세는 것과 댓글을 검색을 위해 준비하는 것을 분리하라

### DIFF
--- a/src/main/java/application/CommentPreparer.java
+++ b/src/main/java/application/CommentPreparer.java
@@ -1,0 +1,63 @@
+package application;
+
+import org.apache.commons.lang3.RegExUtils;
+import org.apache.commons.lang3.StringUtils;
+
+public class CommentPreparer {
+
+    private static final String REGEX = "[^가-힣a-zA-Z]";
+    private static final String REPLACE_EMPTY = "";
+    private static final String[][] ELEMENT_SCHOOL_REPLACES = {
+            {"초"},
+            {"초등학교"}
+    };
+    private static final String[][] MIDDLE_SCHOOL_REPLACES = {
+            {"중", "여중", "체중", "예중"},
+            {"중학교", "여자중", "체육중", "예술중"}
+    };
+    private static final String[][] HIGH_SCHOOL_REPLACES = {
+            {"고", "여고", "체고", "예고"},
+            {"고등학교", "여자고", "체육고", "예술고"}
+    };
+    private static final String[][] UNIV_SCHOOL_REPLACES = {
+            {"[^대구]대", "여대", "체대", "예대"},
+            {"대학교", "여자대", "체육대", "예술대"}
+    };
+
+    /**
+     * 원본 텍스트를 받아 검색을 위한 텍스트로 변경후 반환합니다.
+     */
+    public String[] replaceForSearch(String originalText) {
+        String removedText = removeUnnecessaryCharacters(originalText);
+        return new String[] {
+                replaceEach(removedText, ELEMENT_SCHOOL_REPLACES),
+                replaceEach(removedText, MIDDLE_SCHOOL_REPLACES),
+                replaceEach(removedText, HIGH_SCHOOL_REPLACES),
+                replaceEach(removedText, UNIV_SCHOOL_REPLACES)
+        };
+    }
+
+    /**
+     * 한글 혹은 영문자를 제외한 문자열을 제거 후 반환합니다.
+     *
+     * @param originalText 원본 텍스트
+     * @return 한글 혹은 영문자를 제외한 모든 문자열이 제거된 문자열
+     */
+    private String removeUnnecessaryCharacters(String originalText) {
+        return RegExUtils.replaceAll(originalText, REGEX, REPLACE_EMPTY);
+    }
+
+    /**
+     * 원본 문자열에서 정규식과 일치하는 부분을 대치 후 반환합니다.
+     *
+     * @param originalText 원본 문자열
+     * @param replaces     정규식과 대치할 문자열이 담긴 2차원 배열
+     */
+    private String replaceEach(String originalText, String[][] replaces) {
+        return StringUtils.replaceEachRepeatedly(
+                originalText,
+                replaces[0],
+                replaces[1]
+        );
+    }
+}

--- a/src/main/java/application/CommentsReader.java
+++ b/src/main/java/application/CommentsReader.java
@@ -1,18 +1,14 @@
 package application;
 
 import fileutils.CsvReader;
-import pojo.Comment;
 
 import java.util.List;
-import java.util.regex.Pattern;
 import java.util.stream.StreamSupport;
 
 /** 댓글 목록이 담긴 csv 파일을 읽습니다. */
 public class CommentsReader {
 
     private static final String FILE_NAME = "comments.csv";
-    private static final String REGEX = "[^가-힣a-zA-Z]";
-    private static final Pattern PATTERN = Pattern.compile(REGEX);
 
     private final CsvReader csvReader;
 
@@ -25,26 +21,12 @@ public class CommentsReader {
      *
      * @return 댓글 리스트
      */
-    public List<Comment> read() {
+    public List<String> read() {
         return StreamSupport.stream(
                         csvReader.read(FILE_NAME)
                                 .spliterator(),
                         true
-                ).skip(1)
-                .map(record -> record.get(0))
-                .map((it) -> new Comment(
-                        it,
-                        removeUnnecessaryCharacters(it)
-                )).toList();
-    }
-
-    /**
-     * 한글 혹은 영문자를 제외한 문자열을 제거 후 반환합니다.
-     *
-     * @param originalText 원본 텍스트
-     * @return 한글 혹은 영문자를 제외한 모든 문자열이 제거된 문자열
-     */
-    private String removeUnnecessaryCharacters(String originalText) {
-        return PATTERN.matcher(originalText).replaceAll("");
+                ).map(record -> record.get(0))
+                .toList();
     }
 }

--- a/src/main/java/application/SchoolNameRepetitionCounter.java
+++ b/src/main/java/application/SchoolNameRepetitionCounter.java
@@ -1,8 +1,8 @@
 package application;
 
 import org.apache.commons.lang3.StringUtils;
-import pojo.Comment;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -12,22 +12,11 @@ import java.util.stream.Collectors;
 /** 학교 이름의 반복 횟수를 카운트 합니다. */
 public class SchoolNameRepetitionCounter {
 
-    String[][] ELEMENT_SCHOOL_REPLACES = {
-            {"초"},
-            {"초등학교"}
-    };
-    String[][] MIDDLE_SCHOOL_REPLACES = {
-            {"중", "여중", "체중", "예중"},
-            {"중학교", "여자중", "체육중", "예술중"}
-    };
-    String[][] HIGH_SCHOOL_REPLACES = {
-            {"고", "여고", "체고", "예고"},
-            {"고등학교", "여자고", "체육고", "예술고"}
-    };
-    String[][] UNIV_SCHOOL_REPLACES = {
-            {"[^대구]대", "여대", "체대", "예대"},
-            {"대학교", "여자대", "체육대", "예술대"}
-    };
+    private final CommentPreparer preparer;
+
+    public SchoolNameRepetitionCounter(final CommentPreparer preparer) {
+        this.preparer = preparer;
+    }
 
     /**
      * 댓글 리스트와 학교 이름 리스트가 주어지면, 댓글의 유효한 학교 이름을 찾아내 카운트합니다.
@@ -38,10 +27,11 @@ public class SchoolNameRepetitionCounter {
      * @return 카운트 결과
      */
     public Map<String, Long> countSchoolNameRepetitions(
-            List<Comment> comments,
+            List<String> comments,
             List<String> schools
     ) {
         return comments.parallelStream()
+                .map(preparer::replaceForSearch)
                 .map((it) -> findSchoolName(schools, it))
                 .filter(Objects::nonNull)
                 .collect(
@@ -57,26 +47,27 @@ public class SchoolNameRepetitionCounter {
      * 만약 찾지 못할 경우 null을 반환합니다.
      *
      * @param schools 학교 이름 리스트
-     * @param comment 댓글
+     * @param comments 댓글
      * @return 댓글에서 찾은 학교 이름. 찾지 못하면 null 반환
      */
-    private String findSchoolName(List<String> schools, Comment comment) {
-        String originalText = comment.getText();
-
-        String replaceForElementsSchool = replaceEach(originalText, ELEMENT_SCHOOL_REPLACES);
-        String replaceForMiddleSchool = replaceEach(originalText, MIDDLE_SCHOOL_REPLACES);
-        String replaceForHighSchool = replaceEach(originalText, HIGH_SCHOOL_REPLACES);
-        String replaceForUniversity = replaceEach(originalText, UNIV_SCHOOL_REPLACES);
-
+    private String findSchoolName(List<String> schools, String[] comments) {
         return schools.parallelStream()
                 .filter(school ->
-                        contains(replaceForElementsSchool, school)
-                        || contains(replaceForMiddleSchool, school)
-                        || contains(replaceForHighSchool, school)
-                        || contains(replaceForUniversity, school)
+                        containsAny(comments, school)
                 )
                 .findFirst()
                 .orElse(null);
+    }
+
+    /**
+     * 문자열 배열에서 찾고자하는 문자열을 포함 여부를 반환합니다.
+     *
+     * @param targets 대상 문자열이 담긴 배열
+     * @param searchText 찾고자하는 문자열
+     * @return 포함하고 있는 문자열을 하나라도 찾으면 true, 없으면 false
+     */
+    private boolean containsAny(String[] targets, String searchText) {
+        return Arrays.stream(targets).anyMatch(comment -> contains(comment, searchText));
     }
 
     /**
@@ -88,19 +79,5 @@ public class SchoolNameRepetitionCounter {
      */
     private boolean contains(String target, String searchText) {
         return StringUtils.contains(target, searchText);
-    }
-
-    /**
-     * 원본 문자열에서 정규식과 일치하는 부분을 대치 후 반환합니다.
-     *
-     * @param originalText 원본 문자열
-     * @param replaces 정규식과 대치할 문자열이 담긴 2차원 배열
-     */
-    private String replaceEach(String originalText, String[][] replaces) {
-        return StringUtils.replaceEach(
-                originalText,
-                replaces[0],
-                replaces[1]
-        );
     }
 }


### PR DESCRIPTION
기존에는 SchoolNameRepetitionCounter 클래스에서 댓글 내용을 변경하고, 검색하고, 갯수를 세는 것까지 모두 한 번에 처리했습니다.

댓글을 검색에 편리하게 준비하는 것과 관심사의 분리가 필요하다고 판단하여
해당 역할만 담당하는 CommentPreparer를 만들었습니다.