### PR TITLE
tinylog 의존성을 추가하라

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,10 @@ dependencies {
     // commons-lang
     implementation 'org.apache.commons:commons-lang3:3.12.0'
 
+    // tinylog
+    implementation 'org.tinylog:tinylog-api:2.6.0'
+    implementation 'org.tinylog:tinylog-impl:2.6.0'
+
     // junit
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.1'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.1'

--- a/src/main/resources/tinylog.properties
+++ b/src/main/resources/tinylog.properties
@@ -1,0 +1,7 @@
+writer1        = console
+writer1.format = {date: yyyy-MM-dd HH:mm:ss.SSS} {class-name} {level}: {message}
+
+writer2        = file
+writer2.format = {date: yyyy-MM-dd HH:mm:ss.SSS} {class-name} {level}: {message}
+writer2.file   = result.log
+writer2.level  = info


### PR DESCRIPTION
더 쉽고 간단하게 로그를 출력하고, 파일로 저장하기 위해 `tinylog`라이브러리를 추가했습니다.
설정은 기본적으로 콘솔과 파일에 저장되게만 설정했습니다.

See also
[tinylog](https://tinylog.org/v2/)