### PR TITLE
댓글리스트를 기본 스트림으로 읽어라

### DIFF
--- a/src/main/java/application/CommentsReader.java
+++ b/src/main/java/application/CommentsReader.java
@@ -27,8 +27,9 @@ public class CommentsReader {
             return StreamSupport.stream(
                             csvReader.read(FILE_NAME)
                                     .spliterator(),
-                            true
-                    ).map(record -> record.get(0))
+                            false
+                    ).skip(1)
+                    .map(record -> record.get(0))
                     .toList();
         } catch (IOException e) {
             throw new RuntimeException(e);


### PR DESCRIPTION
기존에는 parallel의 값을 true로 설정하여 병렬 스트림으로 처리하였으나,
댓글리스트는 헤더가 첫 번째 줄에 위치하고 있어 순서대로 읽은 뒤에 첫 번째 줄을 무시해야 하기 때문에 일반 스트림으로 변경합니다.