### PR TITLE
정확하지 않은 학교명은 카운트대상에서 제외하라

### DIFF
--- a/src/main/java/application/SchoolNameRepetitionCounter.java
+++ b/src/main/java/application/SchoolNameRepetitionCounter.java
@@ -75,12 +75,12 @@ public class SchoolNameRepetitionCounter {
                 .findFirst()
                 .orElseGet(() -> {
                     String match = matchSchoolPostfix(comments[0]);
-                    if (match == null) {
-                        Logger.warn("-------------------------------------");
-                        Logger.warn("댓글에서 유효한 학교명을 찾지 못했습니다.\n{}", comments[0]);
-                        return null;
+                    Logger.warn("-".repeat(50));
+                    Logger.warn("아래 댓글에서 유효한 학교명을 찾지 못했습니다.\n{}", comments[0]);
+                    if (match != null) {
+                        Logger.warn("학교 이름으로 추정되는 문자열이 있습니다. : {}", match);
                     }
-                    return match;
+                    return null;
                 });
     }
 


### PR DESCRIPTION
정규식으로 ~학교로 끝나는 부분을 찾아 카운트에 포함시켰었으나,
확실하지 않은 학교명을 카운트하는 것은 정확도에 문제가 생길 수 있을것으로 판단하여 포함 대상에서 제외시켰습니다.
편의를 위해 로그를 출력하는 방법으로 대체합니다.